### PR TITLE
Amend image class

### DIFF
--- a/src/components/singleShowDetails/SingleShowDetails.css
+++ b/src/components/singleShowDetails/SingleShowDetails.css
@@ -1,4 +1,4 @@
-.show-image {
+.single-show-image {
     max-width: 50%;
     height: auto;
 }

--- a/src/components/singleShowDetails/SingleShowDetails.jsx
+++ b/src/components/singleShowDetails/SingleShowDetails.jsx
@@ -54,7 +54,7 @@ export default function ShowDetails({ show, onGoBack }) {
         <div>
           <h3>{title}</h3>
           <p>{description}</p>
-          <img className="show-image" src={showData.image} alt={title} />
+          <img className="single-show-image" src={showData.image} alt={title} />
 
           <SeasonSelector
             seasons={seasons}


### PR DESCRIPTION
Used the same class as for the initial shows display, and that caused the front page shows to be affected by the single show image. Amended with a new classname, all good and picture quality restored